### PR TITLE
Add CSV-based Einheitskontenrahmen and extend reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# codextest
+# Buchhaltungsdemo
+
+Dieses Projekt enthält eine einfache Webanwendung für doppelte Buchhaltung auf Basis von Flask und SQLite. Die Anwendung liest die Konten aus `data/ekr.csv`. Dort kann der komplette österreichische Einheitskontenrahmen hinterlegt werden. Die mitgelieferte Datei enthält nur einen Auszug als Beispiel.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+python run.py
+```
+
+Beim ersten Start wird die Datenbank mit einigen Beispielkonten angelegt.
+
+## Funktionen
+
+* Erfassen von Buchungssätzen (Soll/Haben)
+* Ansicht aller Konten
+* Gewinn- und Verlustrechnung
+* Bilanz
+* Umsatzsteuervoranmeldung
+
+Die Umsetzung dient nur als Demonstration und ist nicht für den produktiven Einsatz geeignet.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///bookkeeping.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+from . import routes  # noqa: E402

--- a/app/db_init.py
+++ b/app/db_init.py
@@ -1,0 +1,15 @@
+import csv
+from pathlib import Path
+from . import db
+from .models import Account
+
+def init_db():
+    db.create_all()
+    if not Account.query.first():
+        csv_path = Path('data/ekr.csv')
+        if csv_path.exists():
+            with csv_path.open(newline='', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                accounts = [Account(number=row['number'], name=row['name'], type=row['type']) for row in reader]
+            db.session.add_all(accounts)
+            db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,23 @@
+from datetime import date
+from . import db
+
+class Account(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.String(10), unique=True, nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    type = db.Column(db.String(20))  # asset, liability, equity, income, expense
+
+    def __repr__(self):
+        return f"{self.number} {self.name}"
+
+class Entry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    entry_date = db.Column(db.Date, default=date.today)
+    description = db.Column(db.String(200))
+    debit_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)
+    credit_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+
+    debit = db.relationship('Account', foreign_keys=[debit_id])
+    credit = db.relationship('Account', foreign_keys=[credit_id])
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,83 @@
+from flask import render_template, request, redirect, url_for
+from . import app, db
+from .models import Account, Entry
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/accounts')
+def accounts():
+    accounts = Account.query.order_by(Account.number).all()
+    return render_template('accounts.html', accounts=accounts)
+
+@app.route('/entries', methods=['GET', 'POST'])
+def entries():
+    accounts = Account.query.order_by(Account.number).all()
+    if request.method == 'POST':
+        debit_id = request.form['debit']
+        credit_id = request.form['credit']
+        amount = float(request.form['amount'])
+        description = request.form.get('description', '')
+        entry = Entry(debit_id=debit_id, credit_id=credit_id, amount=amount, description=description)
+        db.session.add(entry)
+        db.session.commit()
+        return redirect(url_for('entries'))
+    entries = Entry.query.order_by(Entry.entry_date.desc()).all()
+    return render_template('entries.html', entries=entries, accounts=accounts)
+
+@app.route('/profit_loss')
+def profit_loss():
+    income_accounts = Account.query.filter(Account.type=='income').all()
+    expense_accounts = Account.query.filter(Account.type=='expense').all()
+    incomes = []
+    expenses = []
+    income_total = 0
+    expense_total = 0
+    for acc in income_accounts:
+        amount = db.session.query(db.func.sum(Entry.amount)).filter(Entry.credit_id==acc.id).scalar() or 0
+        incomes.append((f"{acc.number} {acc.name}", amount))
+        income_total += amount
+    for acc in expense_accounts:
+        amount = db.session.query(db.func.sum(Entry.amount)).filter(Entry.debit_id==acc.id).scalar() or 0
+        expenses.append((f"{acc.number} {acc.name}", amount))
+        expense_total += amount
+    profit = income_total - expense_total
+    return render_template('profit_loss.html', incomes=incomes, expenses=expenses, income_total=income_total, expense_total=expense_total, profit=profit)
+
+@app.route('/balance')
+def balance():
+    assets = Account.query.filter(Account.type=='asset').all()
+    liabilities = Account.query.filter(Account.type=='liability').all()
+    asset_items = []
+    liability_items = []
+    asset_total = 0
+    liability_total = 0
+    for acc in assets:
+        debit = db.session.query(db.func.sum(Entry.amount)).filter(Entry.debit_id==acc.id).scalar() or 0
+        credit = db.session.query(db.func.sum(Entry.amount)).filter(Entry.credit_id==acc.id).scalar() or 0
+        balance = debit - credit
+        asset_items.append({'name': f"{acc.number} {acc.name}", 'amount': balance})
+        asset_total += balance
+    for acc in liabilities:
+        debit = db.session.query(db.func.sum(Entry.amount)).filter(Entry.debit_id==acc.id).scalar() or 0
+        credit = db.session.query(db.func.sum(Entry.amount)).filter(Entry.credit_id==acc.id).scalar() or 0
+        balance = credit - debit
+        liability_items.append({'name': f"{acc.number} {acc.name}", 'amount': balance})
+        liability_total += balance
+    # align rows for table output
+    length = max(len(asset_items), len(liability_items))
+    rows = []
+    for i in range(length):
+        left = asset_items[i] if i < len(asset_items) else None
+        right = liability_items[i] if i < len(liability_items) else None
+        rows.append((left, right))
+    equity = asset_total - liability_total
+    return render_template('balance.html', rows=rows, asset_total=asset_total, liability_total=liability_total, equity=equity)
+
+@app.route('/vat')
+def vat():
+    vat_income = db.session.query(db.func.sum(Entry.amount)).join(Account, Entry.credit_id==Account.id).filter(Account.name.ilike('%Umsatzsteuer%')).scalar() or 0
+    vat_expense = db.session.query(db.func.sum(Entry.amount)).join(Account, Entry.debit_id==Account.id).filter(Account.name.ilike('%Vorsteuer%')).scalar() or 0
+    vat_due = vat_income - vat_expense
+    return render_template('vat.html', vat_income=vat_income, vat_expense=vat_expense, vat_due=vat_due)

--- a/app/templates/accounts.html
+++ b/app/templates/accounts.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Konten</h2>
+<table border="1">
+<tr><th>Nummer</th><th>Name</th><th>Typ</th></tr>
+{% for acc in accounts %}
+<tr><td>{{ acc.number }}</td><td>{{ acc.name }}</td><td>{{ acc.type }}</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/balance.html
+++ b/app/templates/balance.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Bilanz</h2>
+<table border="1">
+<tr><th>Aktiva</th><th>Betrag</th><th>Passiva</th><th>Betrag</th></tr>
+{% for left, right in rows %}
+<tr>
+  <td>{{ left.name if left else '' }}</td>
+  <td>{{ '%.2f'|format(left.amount) if left else '' }}</td>
+  <td>{{ right.name if right else '' }}</td>
+  <td>{{ '%.2f'|format(right.amount) if right else '' }}</td>
+</tr>
+{% endfor %}
+<tr><td><strong>Summe Aktiva</strong></td><td>{{ '%.2f'|format(asset_total) }}</td>
+    <td><strong>Summe Passiva</strong></td><td>{{ '%.2f'|format(liability_total) }}</td></tr>
+<tr><td colspan="2"></td><td><strong>Eigenkapital</strong></td><td>{{ '%.2f'|format(equity) }}</td></tr>
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Buchhaltung</title>
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a> |
+        <a href="/accounts">Konten</a> |
+        <a href="/entries">Buchungen</a> |
+        <a href="/profit_loss">G+V</a> |
+        <a href="/balance">Bilanz</a> |
+        <a href="/vat">UVA</a>
+    </nav>
+    <hr>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/entries.html
+++ b/app/templates/entries.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Buchungen</h2>
+<form method="post">
+    Soll: <select name="debit">
+        {% for acc in accounts %}
+            <option value="{{ acc.id }}">{{ acc.number }} {{ acc.name }}</option>
+        {% endfor %}
+    </select>
+    Haben: <select name="credit">
+        {% for acc in accounts %}
+            <option value="{{ acc.id }}">{{ acc.number }} {{ acc.name }}</option>
+        {% endfor %}
+    </select>
+    Betrag: <input type="number" step="0.01" name="amount">
+    Text: <input type="text" name="description">
+    <input type="submit" value="Buchen">
+</form>
+<table border="1">
+<tr><th>Datum</th><th>Text</th><th>Soll</th><th>Haben</th><th>Betrag</th></tr>
+{% for e in entries %}
+<tr><td>{{ e.entry_date }}</td><td>{{ e.description }}</td><td>{{ e.debit.number }}</td><td>{{ e.credit.number }}</td><td>{{ e.amount }}</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Willkommen zur Buchhaltung</h1>
+{% endblock %}

--- a/app/templates/profit_loss.html
+++ b/app/templates/profit_loss.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Gewinn- und Verlustrechnung</h2>
+<table border="1">
+<tr><th>Konto</th><th>Betrag</th></tr>
+{% for name, amount in incomes %}
+<tr><td>{{ name }}</td><td>{{ '%.2f'|format(amount) }}</td></tr>
+{% endfor %}
+<tr><td><strong>Summe Erlöse</strong></td><td>{{ '%.2f'|format(income_total) }}</td></tr>
+{% for name, amount in expenses %}
+<tr><td>{{ name }}</td><td>{{ '%.2f'|format(amount) }}</td></tr>
+{% endfor %}
+<tr><td><strong>Summe Aufwendungen</strong></td><td>{{ '%.2f'|format(expense_total) }}</td></tr>
+<tr><td><strong>Gewinn/Verlust</strong></td><td>{{ '%.2f'|format(profit) }}</td></tr>
+</table>
+{% endblock %}

--- a/app/templates/vat.html
+++ b/app/templates/vat.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Umsatzsteuervoranmeldung</h2>
+<table border="1">
+<tr><td>Umsatzsteuer</td><td>{{ '%.2f'|format(vat_income) }}</td></tr>
+<tr><td>Vorsteuer</td><td>{{ '%.2f'|format(vat_expense) }}</td></tr>
+<tr><td><strong>Zahllast</strong></td><td>{{ '%.2f'|format(vat_due) }}</td></tr>
+</table>
+{% endblock %}

--- a/data/ekr.csv
+++ b/data/ekr.csv
@@ -1,0 +1,28 @@
+number,name,type
+0000,Anlagevermögen,asset
+0200,Grundstücke,asset
+0300,Maschinen,asset
+0400,Fuhrpark,asset
+1000,Vorräte,asset
+1100,Rohstoffe,asset
+1200,Halbfertige Erzeugnisse,asset
+1300,Fertigerzeugnisse,asset
+2000,Forderungen aus Lieferungen und Leistungen,asset
+2400,Schecks,asset
+2500,Vorsteuer,asset
+2700,Kassa,asset
+2800,Bank,asset
+3000,Verbindlichkeiten aus Lieferungen und Leistungen,liability
+3200,Bankkredite,liability
+3500,Umsatzsteuer,liability
+4000,Warenerlöse,income
+4300,Erlöse 20%,income
+4400,Erlöse 10%,income
+5000,Materialaufwand,expense
+5700,Wareneinsatz,expense
+6000,Löhne,expense
+6200,Gehälter,expense
+7000,Abschreibungen,expense
+8000,Zinsen,expense
+9000,Eigenkapital,equity
+9600,Gewinnvortrag,equity

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+

--- a/run.py
+++ b/run.py
@@ -1,0 +1,7 @@
+from app import app
+from app.db_init import init_db
+
+if __name__ == '__main__':
+    with app.app_context():
+        init_db()
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- load accounts from `data/ekr.csv` so a complete Einheitskontenrahmen can be provided
- show account balances in profit & loss report
- provide detailed balance sheet table
- display Umsatzsteuer and Vorsteuer in VAT view

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842723db190832983146e8eeaac7550