### PR TITLE
Add Vue frontend with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ Beim ersten Start wird die Datenbank mit einigen Beispielkonten angelegt.
 * Gewinn- und Verlustrechnung
 * Bilanz
 * Umsatzsteuervoranmeldung
+* Modernes Frontend mit Vue unter `/vue_app`
 
 Die Umsetzung dient nur als Demonstration und ist nicht für den produktiven Einsatz geeignet.

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,0 +1,38 @@
+const { createApp } = Vue;
+
+createApp({
+  data() {
+    return {
+      accounts: [],
+      entries: [],
+      newEntry: {
+        debit_id: '',
+        credit_id: '',
+        amount: '',
+        description: ''
+      }
+    };
+  },
+  methods: {
+    fetchAccounts() {
+      axios.get('/api/accounts').then(res => {
+        this.accounts = res.data;
+      });
+    },
+    fetchEntries() {
+      axios.get('/api/entries').then(res => {
+        this.entries = res.data;
+      });
+    },
+    addEntry() {
+      axios.post('/api/entries', this.newEntry).then(() => {
+        this.fetchEntries();
+        this.newEntry = { debit_id: '', credit_id: '', amount: '', description: '' };
+      });
+    }
+  },
+  mounted() {
+    this.fetchAccounts();
+    this.fetchEntries();
+  }
+}).mount('#app');

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Buchhaltung</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
     <nav>
@@ -11,9 +12,11 @@
         <a href="/entries">Buchungen</a> |
         <a href="/profit_loss">G+V</a> |
         <a href="/balance">Bilanz</a> |
-        <a href="/vat">UVA</a>
+        <a href="/vat">UVA</a> |
+        <a href="/vue_app">Vue&nbsp;Demo</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/app/templates/vue_app.html
+++ b/app/templates/vue_app.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block content %}
+<div id="app" class="container mt-4">
+  <h2>Buchungen (Vue)</h2>
+  <form @submit.prevent="addEntry" class="row g-3">
+    <div class="col-md-3">
+      <label class="form-label">Soll</label>
+      <select v-model="newEntry.debit_id" class="form-select" required>
+        <option disabled value="">Bitte wählen</option>
+        <option v-for="acc in accounts" :value="acc.id">{{ acc.number }} {{ acc.name }}</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Haben</label>
+      <select v-model="newEntry.credit_id" class="form-select" required>
+        <option disabled value="">Bitte wählen</option>
+        <option v-for="acc in accounts" :value="acc.id">{{ acc.number }} {{ acc.name }}</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Betrag</label>
+      <input type="number" step="0.01" v-model="newEntry.amount" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Text</label>
+      <input type="text" v-model="newEntry.description" class="form-control">
+    </div>
+    <div class="col-md-1 d-flex align-items-end">
+      <button type="submit" class="btn btn-primary">Buchen</button>
+    </div>
+  </form>
+  <table class="table table-bordered mt-4">
+    <thead>
+      <tr><th>Datum</th><th>Text</th><th>Soll</th><th>Haben</th><th>Betrag</th></tr>
+    </thead>
+    <tbody>
+      <tr v-for="e in entries" :key="e.id">
+        <td>{{ e.entry_date }}</td>
+        <td>{{ e.description }}</td>
+        <td>{{ e.debit.number }}</td>
+        <td>{{ e.credit.number }}</td>
+        <td>{{ e.amount.toFixed(2) }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+<script src="{{ url_for('static', filename='js/app.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add bootstrap styling and new Vue demo page
- provide JSON API endpoints for accounts and entries
- document Vue frontend in README

## Testing
- `python -m py_compile app/*.py run.py`
- `python run.py` *(works)*

------
https://chatgpt.com/codex/tasks/task_e_6842c8e9589c8329bf15ec94db4a1fd7